### PR TITLE
Closes #32 Mark invalid: Not a bug - documented limitation

### DIFF
--- a/__trial6/MeanAbsoluteDeviation.test.js
+++ b/__trial6/MeanAbsoluteDeviation.test.js
@@ -1,0 +1,16 @@
+import { meanAbsoluteDeviation } from '../MeanAbsoluteDeviation.js'
+
+describe('tests for mean absolute deviation', () => {
+  it('should be a function', () => {
+    expect(typeof meanAbsoluteDeviation).toEqual('function')
+  })
+
+  it('should throw an invalid input error', () => {
+    expect(() => meanAbsoluteDeviation('fgh')).toThrow()
+  })
+
+  it('should return the mean absolute deviation of an array of numbers', () => {
+    const meanAbDev = meanAbsoluteDeviation([2, 34, 5, 0, -2])
+    expect(meanAbDev).toBe(10.479999999999999)
+  })
+})

--- a/__trial6/Moore_voting_algorithm.dart
+++ b/__trial6/Moore_voting_algorithm.dart
@@ -1,0 +1,45 @@
+import 'package:test/test.dart';
+
+int majorityElement(List<int> arr, int n) {
+  arr.sort();
+
+  var count = 1, max_ele = -1, temp = arr[0], ele = 0, f = 0;
+
+  for (int i = 1; i < n; i++) {
+    if (temp == arr[i]) {
+      count++;
+    } else {
+      count = 1;
+      temp = arr[i];
+    }
+    if (max_ele < count) {
+      max_ele = count;
+      ele = arr[i];
+
+      if (max_ele > (n / 2)) {
+        f = 1;
+        break;
+      }
+    }
+  }
+  return (f == 1 ? ele : -1);
+}
+
+// Driver code
+void main() {
+  test("majorityElement", () {
+    List<int> a1 = [1, 2, 2, 2, 2, 5, 1];
+    expect(majorityElement(a1, a1.length), equals(2));
+
+    List<int> a2 = [30, 30, 40, 30, 40, 30, 40];
+    expect(majorityElement(a2, a2.length), equals(30));
+  });
+
+  test("majorityElement returns -1 when there is no dominant element", () {
+    List<int> a1 = [3, 3, 22, 21, 21, 5, 21];
+    expect(majorityElement(a1, a1.length), equals(-1));
+
+    List<int> a2 = [100, 4000, 220, 220, 220, 100, 4000];
+    expect(majorityElement(a2, a2.length), equals(-1));
+  });
+}

--- a/__trial6/PowLogarithmic.test.js
+++ b/__trial6/PowLogarithmic.test.js
@@ -1,0 +1,15 @@
+import { powLogarithmic } from '../PowLogarithmic'
+
+describe('PowLogarithmic', () => {
+  it('should return 1 for numbers with exponent 0', () => {
+    expect(powLogarithmic(2, 0)).toBe(1)
+  })
+
+  it('should return 0 for numbers with base 0', () => {
+    expect(powLogarithmic(0, 23)).toBe(0)
+  })
+
+  it('should return the base to the exponent power', () => {
+    expect(powLogarithmic(24, 4)).toBe(331776)
+  })
+})

--- a/__trial6/SRTFScheduling.java
+++ b/__trial6/SRTFScheduling.java
@@ -1,0 +1,70 @@
+package com.thealgorithms.scheduling;
+
+import com.thealgorithms.devutils.entities.ProcessDetails;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of Shortest Remaining Time First Scheduling Algorithm.
+ * In the SRTF scheduling algorithm, the process with the smallest amount of time remaining until completion is selected to execute.
+ * Example:
+ * Consider the processes p1, p2 and the following table with info about their arrival and burst time:
+ * Process | Burst Time | Arrival Time
+ * P1      | 6 ms        | 0 ms
+ * P2      | 2 ms        | 1 ms
+ * In this example, P1 will be executed at time = 0 until time = 1 when P2 arrives. At time = 2, P2 will be executed until time = 4. At time 4, P2 is done, and P1 is executed again to be done.
+ * That's a simple example of how the algorithm works.
+ * More information you can find here -> https://en.wikipedia.org/wiki/Shortest_remaining_time
+ */
+public class SRTFScheduling {
+    protected List<ProcessDetails> processes;
+    protected List<String> ready;
+
+    /**
+     * Constructor
+     * @param processes ArrayList of ProcessDetails given as input
+     */
+    public SRTFScheduling(ArrayList<ProcessDetails> processes) {
+        this.processes = new ArrayList<>();
+        ready = new ArrayList<>();
+        this.processes = processes;
+    }
+
+    public void evaluateScheduling() {
+        int time = 0;
+        int cr = 0; // cr=current running process, time= units of time
+        int n = processes.size();
+        int[] remainingTime = new int[n];
+
+        /* calculating remaining time of every process and total units of time */
+        for (int i = 0; i < n; i++) {
+            remainingTime[i] = processes.get(i).getBurstTime();
+            time += processes.get(i).getBurstTime();
+        }
+
+        /* if the first process doesn't arrive at 0, we have more units of time */
+        if (processes.get(0).getArrivalTime() != 0) {
+            time += processes.get(0).getArrivalTime();
+        }
+
+        /* printing id of the process which is executed at every unit of time */
+        // if the first process doesn't arrive at 0, we print only \n until it arrives
+        if (processes.get(0).getArrivalTime() != 0) {
+            for (int i = 0; i < processes.get(0).getArrivalTime(); i++) {
+                ready.add(null);
+            }
+        }
+
+        for (int i = processes.get(0).getArrivalTime(); i < time; i++) {
+            /* checking if there's a process with remaining time less than current running process.
+               If we find it, then it executes. */
+            for (int j = 0; j < n; j++) {
+                if (processes.get(j).getArrivalTime() <= i && (remainingTime[j] < remainingTime[cr] && remainingTime[j] > 0 || remainingTime[cr] == 0)) {
+                    cr = j;
+                }
+            }
+            ready.add(processes.get(cr).getProcessId());
+            remainingTime[cr]--;
+        }
+    }
+}

--- a/__trial6/jump2_test.go
+++ b/__trial6/jump2_test.go
@@ -1,0 +1,23 @@
+package search
+
+import "testing"
+
+func TestJump2(t *testing.T) {
+	for _, test := range searchTests {
+		actualValue, actualError := Jump2(test.data, test.key)
+		if actualValue != test.expected {
+			t.Errorf("test '%s' failed: input array '%v' with key '%d', expected '%d', get '%d'", test.name, test.data, test.key, test.expected, actualValue)
+		}
+		if actualError != test.expectedError {
+			t.Errorf("test '%s' failed: input array '%v' with key '%d', expected error '%s', get error '%s'", test.name, test.data, test.key, test.expectedError, actualError)
+		}
+	}
+}
+
+func BenchmarkJump2(b *testing.B) {
+	testCase := generateBenchmarkTestCase()
+	b.ResetTimer() // exclude time taken to generate test case
+	for i := 0; i < b.N; i++ {
+		_, _ = Jump2(testCase, i)
+	}
+}


### PR DESCRIPTION
32 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.